### PR TITLE
fix: match nnU-Net LR scheduler mode and default epochs

### DIFF
--- a/src/engines/ignite_utils/trainer.py
+++ b/src/engines/ignite_utils/trainer.py
@@ -206,7 +206,7 @@ def create_trainer(
 
     # Create learning rate scheduler
     lr_config = cfg.get("lr_scheduler", {})
-    mode = lr_config.get("mode", "linear")
+    mode = lr_config.get("mode", "poly")
     decay_rate = lr_config.get("decay_rate", 0.00001)
     exponent = lr_config.get("exponent", 0.9)
 

--- a/src/planning/constants.py
+++ b/src/planning/constants.py
@@ -71,7 +71,7 @@ class PlanningConstants:
     # ========================================================================
     # Training Hyperparameters
     # ========================================================================
-    EPOCHS: int = 5
+    EPOCHS: int = 1000
     LEARNING_RATE: float = 0.01
     VAL_INTERVAL: int = 1
     WEIGHT_DECAY: float = 0.00003


### PR DESCRIPTION
## Summary
- Change LR scheduler default from `linear` to `poly` to match nnU-Net's PolyLRScheduler (exponent=0.9)
- Change default epochs from 5 to 1000 to match nnU-Net

## Test plan
- [ ] Run `nnBench.plan` and verify generated config has `epochs: 1000`
- [ ] Run training and verify LR follows polynomial decay curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)